### PR TITLE
Added support for formatted text in AvaloniaRepl

### DIFF
--- a/AvaloniaRepl/HtmlTextFormatter.cs
+++ b/AvaloniaRepl/HtmlTextFormatter.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Data.Converters;
+
+namespace AvaloniaRepl
+{
+    public class HtmlTextFormatter : IValueConverter
+    {
+        public readonly static HtmlTextFormatter Instance = new HtmlTextFormatter();
+
+        public static void SetFormattedText(TextBlock textBlock, string formattedText)
+        {
+            textBlock.Inlines.Clear();
+            textBlock.Inlines.Add(ParseHtml(formattedText));
+        }
+
+        private static readonly char[] separators = { '<', '>' };
+
+        /// <summary>
+        /// Convert an HTML-ish string into an Avalonia "Span",
+        /// </summary>
+        /// <param name="html"></param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        public static Span ParseHtml(string html)
+        {
+            var split = Regex.Split(html, @"(\<|\>)").Where(s => s != "").ToArray();
+            var tokens = new Queue<string>(split);
+            var stack = new Stack<(string terminator, Span data)>();
+            var topLevelSpan = new Span();
+            stack.Push(("", topLevelSpan));
+
+            void AddToken(string token) => stack.Peek().data.Inlines.Add(token);
+
+            void StartSpan(string start, string end, Span span)
+            {
+                var closeToken = NextToken();
+                if (closeToken != ">")
+                {
+                    AddToken("<");
+                    AddToken(start);
+                    AddToken(closeToken);
+                }
+                else
+                {
+                    stack.Push((end, span));
+                }
+            }
+
+            void EndSpan()
+            {
+                var current = stack.Pop().data;
+                if (stack.Count > 0)
+                    stack.Peek().data.Inlines.Add(current);
+            }
+
+            string NextToken()
+            {
+                if (tokens.Count == 0)
+                    return "";
+                return tokens.Dequeue();
+            }
+
+            while (tokens.Count > 0)
+            {
+                var t = NextToken();
+                switch (t)
+                {
+                    case "<":
+                        var type = NextToken();
+                        switch (type.Trim())
+                        {
+                            case "b":
+                                StartSpan(t, "/b", new Bold());
+                                break;
+
+                            case "i":
+                                StartSpan(t, "/i", new Italic());
+                                break;
+
+                            default:
+                                var close = NextToken();
+                                if (type.Replace(" ", "") == stack.Peek().terminator && close == ">")
+                                {
+                                    EndSpan();
+                                }
+                                else
+                                {
+                                    AddToken("<");
+                                    AddToken(t);
+                                    AddToken(close);
+                                }
+
+                                break;
+                        }
+                        break;
+
+                    default:
+                        AddToken(t);
+                        break;
+                }
+            }
+
+            while (stack.Count > 0) EndSpan();
+            return topLevelSpan;
+        }
+
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            var str = value as string;
+            if (str == null || targetType != typeof(InlineCollection))
+                throw new NotImplementedException();
+            return new InlineCollection() { ParseHtml(str) };
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/AvaloniaRepl/Views/MainWindow.axaml
+++ b/AvaloniaRepl/Views/MainWindow.axaml
@@ -5,11 +5,16 @@
         xmlns:vm="using:AvaloniaRepl.ViewModels"
         xmlns:interpreter="clr-namespace:Step.Interpreter;assembly=Step"
         xmlns:system="clr-namespace:System;assembly=System.Runtime"
+        xmlns:local="clr-namespace:AvaloniaRepl"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="AvaloniaRepl.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
         Icon="/Assets/cat-icon.png"
         Title="StepRepl">
+
+    <Window.Resources>
+        <local:HtmlTextFormatter x:Key="htmlTextFormatter"/>
+    </Window.Resources>
     
     <Design.DataContext>
         <!-- This only sets the DataContext for the previewer in an IDE,
@@ -71,7 +76,7 @@
                         <ListBox x:Name="StackTrace" SelectionMode="Single" SelectionChanged="StackFrameSelected">
                             <ListBox.ItemTemplate>
                                 <DataTemplate x:DataType="interpreter:MethodCallFrame">
-                                        <SelectableTextBlock Text="{Binding CallSourceText}" Foreground="DarkOrange" FontSize="14" TextWrapping="Wrap"
+                                        <SelectableTextBlock Inlines="{Binding CallSourceText, Converter={StaticResource htmlTextFormatter}}" Foreground="DarkOrange" FontSize="14" TextWrapping="Wrap"
                                                              ToolTip.Tip ="This is a task that was running when the error occurred.  You can click on it to view the code for the task in Visual Studio Code."/>
                                 </DataTemplate>
                             </ListBox.ItemTemplate>
@@ -87,7 +92,7 @@
                 <ListBox x:Name="WarningText" SelectionMode="Single" SelectionChanged="WarningSelected">
                     <ListBox.ItemTemplate>
                         <DataTemplate x:DataType="interpreter:WarningInfo">
-                                <SelectableTextBlock Text="{Binding Warning}" Foreground="Yellow" FontSize="14" TextWrapping="Wrap" 
+                                <SelectableTextBlock Inlines="{Binding Warning, Converter={StaticResource htmlTextFormatter}}" Foreground="Yellow" FontSize="14" TextWrapping="Wrap" 
                                                      ToolTip.Tip ="Click to view in Visual Studio Code."/>
                         </DataTemplate>
                     </ListBox.ItemTemplate>

--- a/AvaloniaRepl/Views/MainWindow.axaml.cs
+++ b/AvaloniaRepl/Views/MainWindow.axaml.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Input;
 using Avalonia.Controls;
+using Avalonia.Controls.Documents;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
@@ -200,11 +201,10 @@ public partial class MainWindow : Window
     /// <param name="evalTask">Task that runs the step code and returns its output text</param>
     async Task EvalAndShowOutput(Task<string> evalTask)
     {
-        // Call code and update text
-        OutputText.Text = await evalTask;
+        HtmlTextFormatter.SetFormattedText(OutputText, await evalTask);
+
         // Update exception info
         UpdateExceptionInfo();
     }
-    
     #endregion
 }


### PR DESCRIPTION
Right now, it only supports the <b> and <i> html tags.

It turns out the only way to do formatted text at run time is to manually build the tree of "inlines", which are regions of text formatting.  HtmlTextFormatter contains a very simplistic method for doing that called ParseHtml.  It's also declared to be a "IValueConverter", that can convert from type string to type InlineCollection, which is the actual object you store into the TextBlock or SelectableTextBlock to get formatted text.

So to use this with a TextBlock, you either say HtmlTextFormatter.SetFormattedText(textblock, string), or if you're in xaml land, you change Text={Binding foo} to Inlines={Binding foo, Converter={htmlTextFormatter}}.  Don't ask.